### PR TITLE
chore: Prepare for mono repository migration

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -36,12 +36,6 @@ for library in s.get_staging_dirs(default_version):
         shutil.rmtree("samples/generated_samples", ignore_errors=True)
         clean_up_generated_samples = False
 
-    # Remove replacement once this repository has migrated to google-cloud-python
-    s.replace(
-        "setup.py",
-        """url = \"https://github.com/googleapis/python-public-ca\"""",
-        """url = \"https://github.com/googleapis/python-security-public-ca\"""",
-    )
     s.move([library], excludes=["**/gapic_version.py"])
 s.remove_staging_dirs()
 


### PR DESCRIPTION
Remove replacement in owlbot.py which will be obsolete in the monorepo


Remove replacement in owlbot.py which will be obsolete in the monorepo as the reason for the customization was due to the discrepancy between the package name `google-cloud-public-ca` and the repository name `python-security-public-ca`. In the monorepo, we will have package `google-cloud-public-ca` which is predictable.
